### PR TITLE
Starts timer only when you start typing

### DIFF
--- a/tutorial.py
+++ b/tutorial.py
@@ -52,6 +52,9 @@ def wpm_test(stdscr):
 		except:
 			continue
 
+		if current_text == []:
+			start_time = time.time()
+
 		if ord(key) == 27:
 			break
 


### PR DESCRIPTION
Timer begins when you start typing and can be reset by returning to the beginning.
This slight adjustment was well received in the comment section and liked by Tim.